### PR TITLE
Add ability to override the separatorColor on TimelineView

### DIFF
--- a/KVKCalendar/Classes/Style.swift
+++ b/KVKCalendar/Classes/Style.swift
@@ -96,6 +96,7 @@ public struct TimelineStyle {
     public var currentLineHourDotCornersRadius: CGSize = CGSize(width: 2.5, height: 2.5)
     public var currentLineHourWidth: CGFloat = 60
     public var currentLineHourHeight: CGFloat = 1
+    public var separatorLineColor: UIColor = .gray
     public var movingMinutesColor: UIColor = .systemBlue
     public var shadowColumnColor: UIColor = .systemTeal
     public var shadowColumnAlpha: CGFloat = 0.1

--- a/KVKCalendar/Classes/Timeline+Extension.swift
+++ b/KVKCalendar/Classes/Timeline+Extension.swift
@@ -68,7 +68,7 @@ extension TimelineView {
                                    width: frame.width - xLine,
                                    height: style.timeline.heightLine)
             let line = UIView(frame: lineFrame)
-            line.backgroundColor = .gray
+            line.backgroundColor = style.timeline.separatorLineColor
             line.tag = idx
             lines.append(line)
         }


### PR DESCRIPTION
Added new public variable: `separatorLineColor` to `TimelineStyle`

Changed `TimelineView` function `createLines` to now use the new public variable