### PR TITLE
Allow customisation of timelines' event views' frame

### DIFF
--- a/Sources/KVKCalendar/DefaultTimelineEventLayout.swift
+++ b/Sources/KVKCalendar/DefaultTimelineEventLayout.swift
@@ -8,36 +8,36 @@
 import UIKit
 
 public struct DefaultTimelineEventLayout: TimelineEventLayout {
-	public func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect] {
-		var rects: [CGRect] = []
+    public func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect] {
+        var rects: [CGRect] = []
 
-		let crossEvents = context.calculateCrossEvents(forEvents: events)
+        let crossEvents = context.calculateCrossEvents(forEvents: events)
 
-		for event in events {
-			var frame = context.getEventRect(start: event.start, end: event.end, date: date, style: event.style)
+        for event in events {
+            var frame = context.getEventRect(start: event.start, end: event.end, date: date, style: event.style)
 
-			// calculate 'width' and position 'x'
-			if let crossEvent = crossEvents[event.start.timeIntervalSince1970] {
-				var newOriginX = frame.origin.x
-				var newWidth = frame.width
-				newWidth /= CGFloat(crossEvent.events.count)
-				newWidth -= context.style.timeline.offsetEvent
-				frame.size.width = newWidth
+            // calculate 'width' and position 'x'
+            if let crossEvent = crossEvents[event.start.timeIntervalSince1970] {
+                var newOriginX = frame.origin.x
+                var newWidth = frame.width
+                newWidth /= CGFloat(crossEvent.events.count)
+                newWidth -= context.style.timeline.offsetEvent
+                frame.size.width = newWidth
 
-				if crossEvent.events.count > 1 {
-					for rect in rects {
-						while rect.intersects(CGRect(x: newOriginX, y: frame.origin.y, width: frame.width, height: frame.height)) {
-							newOriginX += (rect.width + context.style.timeline.offsetEvent).rounded()
-						}
-					}
-				}
+                if crossEvent.events.count > 1 {
+                    for rect in rects {
+                        while rect.intersects(CGRect(x: newOriginX, y: frame.origin.y, width: frame.width, height: frame.height)) {
+                            newOriginX += (rect.width + context.style.timeline.offsetEvent).rounded()
+                        }
+                    }
+                }
 
-				frame.origin.x = newOriginX
-			}
+                frame.origin.x = newOriginX
+            }
 
-			rects.append(frame)
-		}
+            rects.append(frame)
+        }
 
-		return rects
-	}
+        return rects
+    }
 }

--- a/Sources/KVKCalendar/DefaultTimelineEventLayout.swift
+++ b/Sources/KVKCalendar/DefaultTimelineEventLayout.swift
@@ -1,0 +1,43 @@
+//
+//  DefaultTimelineEventLayout.swift
+//  KVKCalendar
+//
+//  Created by Tom Knapen on 12/07/2021.
+//
+
+import UIKit
+
+public struct DefaultTimelineEventLayout: TimelineEventLayout {
+	public func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect] {
+		var rects: [CGRect] = []
+
+		let crossEvents = context.calculateCrossEvents(forEvents: events)
+
+		for event in events {
+			var frame = context.getEventRect(start: event.start, end: event.end, date: date, style: event.style)
+
+			// calculate 'width' and position 'x'
+			if let crossEvent = crossEvents[event.start.timeIntervalSince1970] {
+				var newOriginX = frame.origin.x
+				var newWidth = frame.width
+				newWidth /= CGFloat(crossEvent.events.count)
+				newWidth -= context.style.timeline.offsetEvent
+				frame.size.width = newWidth
+
+				if crossEvent.events.count > 1 {
+					for rect in rects {
+						while rect.intersects(CGRect(x: newOriginX, y: frame.origin.y, width: frame.width, height: frame.height)) {
+							newOriginX += (rect.width + context.style.timeline.offsetEvent).rounded()
+						}
+					}
+				}
+
+				frame.origin.x = newOriginX
+			}
+
+			rects.append(frame)
+		}
+
+		return rects
+	}
+}

--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -138,6 +138,8 @@ public struct TimelineStyle {
     public var isEnabledCreateNewEvent: Bool = true
     public var maxLimitChachedPages: UInt = 10
     public var scrollDirections: Set<ScrollDirectionType> = Set(ScrollDirectionType.allCases)
+
+	public var eventLayout: TimelineEventLayout = DefaultTimelineEventLayout()
     
     public enum ScrollDirectionType: Int, CaseIterable {
         case vertical, horizontal

--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -139,7 +139,7 @@ public struct TimelineStyle {
     public var maxLimitChachedPages: UInt = 10
     public var scrollDirections: Set<ScrollDirectionType> = Set(ScrollDirectionType.allCases)
 
-	public var eventLayout: TimelineEventLayout = DefaultTimelineEventLayout()
+    public var eventLayout: TimelineEventLayout = DefaultTimelineEventLayout()
     
     public enum ScrollDirectionType: Int, CaseIterable {
         case vertical, horizontal

--- a/Sources/KVKCalendar/TimelineEventLayout.swift
+++ b/Sources/KVKCalendar/TimelineEventLayout.swift
@@ -1,0 +1,105 @@
+//
+//  TimelineEventLayout.swift
+//  KVKCalendar
+//
+//  Created by Tom Knapen on 12/07/2021.
+//
+
+import UIKit
+
+public struct TimelineEventLayoutContext {
+	public let style: Style
+	let pageFrame: CGRect
+	let startHour: Int
+	let timeLabels: [TimelineLabel]
+	let calculatePointYByMinute: (_ minute: Int, _ label: TimelineLabel) -> CGFloat
+	let getTimelineLabel: (_ hour: Int) -> TimelineLabel?
+}
+
+public protocol TimelineEventLayout {
+	func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect]
+}
+
+public extension TimelineEventLayoutContext {
+	func getEventRect(start: Date, end: Date, date: Date?, style eventStyle: EventStyle?) -> CGRect {
+		var newFrame = pageFrame
+		let midnight = 24
+
+		for time in timeLabels {
+			// calculate position 'y'
+			if start.hour.hashValue == time.valueHash, start.day == date?.day {
+				if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
+					newFrame.origin.y = calculatePointYByMinute(start.minute, newTime)
+				} else {
+					newFrame.origin.y = calculatePointYByMinute(start.minute, time)
+				}
+			} else if let firstTimeLabel = getTimelineLabel(startHour), start.day != date?.day {
+				newFrame.origin.y = calculatePointYByMinute(startHour, firstTimeLabel)
+			}
+
+			// calculate 'height' event
+			if let defaultHeight = eventStyle?.defaultHeight {
+				newFrame.size.height = defaultHeight
+			} else if let globalDefaultHeight = style.event.defaultHeight {
+				newFrame.size.height = globalDefaultHeight
+			} else if end.hour.hashValue == time.valueHash, end.day == date?.day {
+				var timeTemp = time
+				if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
+					timeTemp = newTime
+				}
+
+				let summHeight = (CGFloat(timeTemp.tag) * (style.timeline.offsetTimeY + timeTemp.frame.height)) - newFrame.origin.y + (timeTemp.frame.height / 2)
+				if 0...59 ~= end.minute {
+					let minutePercent = 59.0 / CGFloat(end.minute)
+					let newY = (style.timeline.offsetTimeY + timeTemp.frame.height) / minutePercent
+					newFrame.size.height = summHeight + newY - style.timeline.offsetEvent
+				} else {
+					newFrame.size.height = summHeight - style.timeline.offsetEvent
+				}
+			} else if end.day != date?.day {
+				newFrame.size.height = (CGFloat(time.tag) * (style.timeline.offsetTimeY + time.frame.height)) - newFrame.origin.y + (time.frame.height / 2)
+			}
+		}
+
+		return newFrame
+	}
+}
+
+// MARK: - Helpers
+
+public extension TimelineEventLayoutContext {
+	// count event cross in one hour
+	func calculateCrossEvents(forEvents events: [Event]) -> [TimeInterval: CrossEvent] {
+		var eventsTemp = events
+		var crossEvents = [TimeInterval: CrossEvent]()
+
+		while let event = eventsTemp.first {
+			let start = event.start.timeIntervalSince1970
+			let end = event.end.timeIntervalSince1970
+			var crossEventNew = CrossEvent(eventTime: EventTime(start: start, end: end))
+			let endCalculated: TimeInterval = crossEventNew.eventTime.end - TimeInterval(style.timeline.offsetEvent)
+			crossEventNew.events = events.filter { item in
+				let itemEnd = item.end.timeIntervalSince1970 - TimeInterval(style.timeline.offsetEvent)
+				let itemStart = item.start.timeIntervalSince1970
+				guard itemEnd > itemStart else { return false }
+
+				return (itemStart...itemEnd).contains(start) || (itemStart...itemEnd).contains(endCalculated) || (start...endCalculated).contains(itemStart) || (start...endCalculated).contains(itemEnd)
+			}
+
+			crossEvents[crossEventNew.eventTime.start] = crossEventNew
+			eventsTemp.removeFirst()
+		}
+
+		return crossEvents
+	}
+}
+
+public struct EventTime: Equatable, Hashable {
+	public let start: TimeInterval
+	public let end: TimeInterval
+}
+
+public struct CrossEvent {
+	public let eventTime: EventTime
+	public var events: [Event] = []
+}

--- a/Sources/KVKCalendar/TimelineEventLayout.swift
+++ b/Sources/KVKCalendar/TimelineEventLayout.swift
@@ -8,98 +8,98 @@
 import UIKit
 
 public struct TimelineEventLayoutContext {
-	public let style: Style
-	let pageFrame: CGRect
-	let startHour: Int
-	let timeLabels: [TimelineLabel]
-	let calculatePointYByMinute: (_ minute: Int, _ label: TimelineLabel) -> CGFloat
-	let getTimelineLabel: (_ hour: Int) -> TimelineLabel?
+    public let style: Style
+    let pageFrame: CGRect
+    let startHour: Int
+    let timeLabels: [TimelineLabel]
+    let calculatePointYByMinute: (_ minute: Int, _ label: TimelineLabel) -> CGFloat
+    let getTimelineLabel: (_ hour: Int) -> TimelineLabel?
 }
 
 public protocol TimelineEventLayout {
-	func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect]
+    func getEventRects(forEvents events: [Event], date: Date?, context: TimelineEventLayoutContext) -> [CGRect]
 }
 
 public extension TimelineEventLayoutContext {
-	func getEventRect(start: Date, end: Date, date: Date?, style eventStyle: EventStyle?) -> CGRect {
-		var newFrame = pageFrame
-		let midnight = 24
+    func getEventRect(start: Date, end: Date, date: Date?, style eventStyle: EventStyle?) -> CGRect {
+        var newFrame = pageFrame
+        let midnight = 24
 
-		for time in timeLabels {
-			// calculate position 'y'
-			if start.hour.hashValue == time.valueHash, start.day == date?.day {
-				if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
-					newFrame.origin.y = calculatePointYByMinute(start.minute, newTime)
-				} else {
-					newFrame.origin.y = calculatePointYByMinute(start.minute, time)
-				}
-			} else if let firstTimeLabel = getTimelineLabel(startHour), start.day != date?.day {
-				newFrame.origin.y = calculatePointYByMinute(startHour, firstTimeLabel)
-			}
+        for time in timeLabels {
+            // calculate position 'y'
+            if start.hour.hashValue == time.valueHash, start.day == date?.day {
+                if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
+                    newFrame.origin.y = calculatePointYByMinute(start.minute, newTime)
+                } else {
+                    newFrame.origin.y = calculatePointYByMinute(start.minute, time)
+                }
+            } else if let firstTimeLabel = getTimelineLabel(startHour), start.day != date?.day {
+                newFrame.origin.y = calculatePointYByMinute(startHour, firstTimeLabel)
+            }
 
-			// calculate 'height' event
-			if let defaultHeight = eventStyle?.defaultHeight {
-				newFrame.size.height = defaultHeight
-			} else if let globalDefaultHeight = style.event.defaultHeight {
-				newFrame.size.height = globalDefaultHeight
-			} else if end.hour.hashValue == time.valueHash, end.day == date?.day {
-				var timeTemp = time
-				if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
-					timeTemp = newTime
-				}
+            // calculate 'height' event
+            if let defaultHeight = eventStyle?.defaultHeight {
+                newFrame.size.height = defaultHeight
+            } else if let globalDefaultHeight = style.event.defaultHeight {
+                newFrame.size.height = globalDefaultHeight
+            } else if end.hour.hashValue == time.valueHash, end.day == date?.day {
+                var timeTemp = time
+                if time.tag == midnight, let newTime = timeLabels.first(where: { $0.tag == 0 }) {
+                    timeTemp = newTime
+                }
 
-				let summHeight = (CGFloat(timeTemp.tag) * (style.timeline.offsetTimeY + timeTemp.frame.height)) - newFrame.origin.y + (timeTemp.frame.height / 2)
-				if 0...59 ~= end.minute {
-					let minutePercent = 59.0 / CGFloat(end.minute)
-					let newY = (style.timeline.offsetTimeY + timeTemp.frame.height) / minutePercent
-					newFrame.size.height = summHeight + newY - style.timeline.offsetEvent
-				} else {
-					newFrame.size.height = summHeight - style.timeline.offsetEvent
-				}
-			} else if end.day != date?.day {
-				newFrame.size.height = (CGFloat(time.tag) * (style.timeline.offsetTimeY + time.frame.height)) - newFrame.origin.y + (time.frame.height / 2)
-			}
-		}
+                let summHeight = (CGFloat(timeTemp.tag) * (style.timeline.offsetTimeY + timeTemp.frame.height)) - newFrame.origin.y + (timeTemp.frame.height / 2)
+                if 0...59 ~= end.minute {
+                    let minutePercent = 59.0 / CGFloat(end.minute)
+                    let newY = (style.timeline.offsetTimeY + timeTemp.frame.height) / minutePercent
+                    newFrame.size.height = summHeight + newY - style.timeline.offsetEvent
+                } else {
+                    newFrame.size.height = summHeight - style.timeline.offsetEvent
+                }
+            } else if end.day != date?.day {
+                newFrame.size.height = (CGFloat(time.tag) * (style.timeline.offsetTimeY + time.frame.height)) - newFrame.origin.y + (time.frame.height / 2)
+            }
+        }
 
-		return newFrame
-	}
+        return newFrame
+    }
 }
 
 // MARK: - Helpers
 
 public extension TimelineEventLayoutContext {
-	// count event cross in one hour
-	func calculateCrossEvents(forEvents events: [Event]) -> [TimeInterval: CrossEvent] {
-		var eventsTemp = events
-		var crossEvents = [TimeInterval: CrossEvent]()
+    // count event cross in one hour
+    func calculateCrossEvents(forEvents events: [Event]) -> [TimeInterval: CrossEvent] {
+        var eventsTemp = events
+        var crossEvents = [TimeInterval: CrossEvent]()
 
-		while let event = eventsTemp.first {
-			let start = event.start.timeIntervalSince1970
-			let end = event.end.timeIntervalSince1970
-			var crossEventNew = CrossEvent(eventTime: EventTime(start: start, end: end))
-			let endCalculated: TimeInterval = crossEventNew.eventTime.end - TimeInterval(style.timeline.offsetEvent)
-			crossEventNew.events = events.filter { item in
-				let itemEnd = item.end.timeIntervalSince1970 - TimeInterval(style.timeline.offsetEvent)
-				let itemStart = item.start.timeIntervalSince1970
-				guard itemEnd > itemStart else { return false }
+        while let event = eventsTemp.first {
+            let start = event.start.timeIntervalSince1970
+            let end = event.end.timeIntervalSince1970
+            var crossEventNew = CrossEvent(eventTime: EventTime(start: start, end: end))
+            let endCalculated: TimeInterval = crossEventNew.eventTime.end - TimeInterval(style.timeline.offsetEvent)
+            crossEventNew.events = events.filter { item in
+                let itemEnd = item.end.timeIntervalSince1970 - TimeInterval(style.timeline.offsetEvent)
+                let itemStart = item.start.timeIntervalSince1970
+                guard itemEnd > itemStart else { return false }
 
-				return (itemStart...itemEnd).contains(start) || (itemStart...itemEnd).contains(endCalculated) || (start...endCalculated).contains(itemStart) || (start...endCalculated).contains(itemEnd)
-			}
+                return (itemStart...itemEnd).contains(start) || (itemStart...itemEnd).contains(endCalculated) || (start...endCalculated).contains(itemStart) || (start...endCalculated).contains(itemEnd)
+            }
 
-			crossEvents[crossEventNew.eventTime.start] = crossEventNew
-			eventsTemp.removeFirst()
-		}
+            crossEvents[crossEventNew.eventTime.start] = crossEventNew
+            eventsTemp.removeFirst()
+        }
 
-		return crossEvents
-	}
+        return crossEvents
+    }
 }
 
 public struct EventTime: Equatable, Hashable {
-	public let start: TimeInterval
-	public let end: TimeInterval
+    public let start: TimeInterval
+    public let end: TimeInterval
 }
 
 public struct CrossEvent {
-	public let eventTime: EventTime
-	public var events: [Event] = []
+    public let eventTime: EventTime
+    public var events: [Event] = []
 }

--- a/Sources/KVKCalendar/TimelineModel.swift
+++ b/Sources/KVKCalendar/TimelineModel.swift
@@ -7,35 +7,9 @@
 
 import UIKit
 
-struct CrossEvent: Hashable {
-    let eventTime: EventTime
-    var count: Int
-    
-    init(eventTime: EventTime, count: Int = 1) {
-        self.eventTime = eventTime
-        self.count = count
-    }
-    
-    static func == (lhs: CrossEvent, rhs: CrossEvent) -> Bool {
-        return lhs.eventTime == rhs.eventTime
-            && lhs.count == rhs.count
-    }
-}
-
-extension CrossEvent {
-    var displayValue: String {
-        return "\(Date(timeIntervalSince1970: eventTime.start).toLocalTime()) - \(Date(timeIntervalSince1970: eventTime.end).toLocalTime()) = \(count)"
-    }
-}
-
 struct TimeContainer {
     var minute: Int
     var hour: Int
-}
-
-struct EventTime: Equatable, Hashable {
-    let start: TimeInterval
-    let end: TimeInterval
 }
 
 typealias ResizeTime = (hour: Int, minute: Int)

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -46,8 +46,8 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
     private(set) var dates = [Date?]()
     private(set) var selectedDate: Date?
     private(set) var type: CalendarType
-	private(set) var eventLayout: TimelineEventLayout
-    
+    private(set) var eventLayout: TimelineEventLayout
+
     private(set) lazy var shadowView: ShadowDayView = {
         let view = ShadowDayView()
         view.backgroundColor = style.timeline.shadowColumnColor
@@ -83,7 +83,7 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         self.timeSystem = style.timeSystem
         self.availabilityHours = timeSystem.hours
         self.style = style
-		self.eventLayout = style.timeline.eventLayout
+        self.eventLayout = style.timeline.eventLayout
         super.init(frame: frame)
         
         var scrollFrame = frame
@@ -312,33 +312,33 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
                                       xOffset: pointX - leftOffset,
                                       width: widthPage))
 
-			do {
-				let context = TimelineEventLayoutContext(
-					style: style,
-					pageFrame: .init(x: pointX, y: 0, width: widthPage, height: heightPage),
-					startHour: startHour,
-					timeLabels: timeLabels,
-					calculatePointYByMinute: calculatePointYByMinute(_:time:),
-					getTimelineLabel: getTimelineLabel(hour:)
-				)
-				let rects = eventLayout.getEventRects(
-					forEvents: sortedEventsByDate,
-					date: date,
-					context: context
-				)
-				for (event, rect) in zip(sortedEventsByDate, rects) {
-					let view: EventViewGeneral = {
-						if let view = dataSource?.willDisplayEventView(event, frame: rect, date: date) {
-							return view
-						} else {
-							return EventView(event: event, style: style, frame: rect)
-						}
-					}()
+            do {
+                let context = TimelineEventLayoutContext(
+                    style: style,
+                    pageFrame: .init(x: pointX, y: 0, width: widthPage, height: heightPage),
+                    startHour: startHour,
+                    timeLabels: timeLabels,
+                    calculatePointYByMinute: calculatePointYByMinute(_:time:),
+                    getTimelineLabel: getTimelineLabel(hour:)
+                )
+                let rects = eventLayout.getEventRects(
+                    forEvents: sortedEventsByDate,
+                    date: date,
+                    context: context
+                )
+                for (event, rect) in zip(sortedEventsByDate, rects) {
+                    let view: EventViewGeneral = {
+                        if let view = dataSource?.willDisplayEventView(event, frame: rect, date: date) {
+                            return view
+                        } else {
+                            return EventView(event: event, style: style, frame: rect)
+                        }
+                    }()
 
-					view.delegate = self
-					view.dataSource = self
-					scrollView.addSubview(view)
-				}
+                    view.delegate = self
+                    view.dataSource = self
+                    scrollView.addSubview(view)
+                }
             }
             
             if !style.timeline.isHiddenStubEvent, let day = date?.day {


### PR DESCRIPTION
This PR separates the timelines' calculation of event view frames.
This enables the user of the library to define custom logic for positioning / sizing event views.

The use-case for me to implement this is to support "background" events which appear behind other events displayed by the timeline, which was not possible with the original implementation of `TimelineView`.

![screenshot](https://user-images.githubusercontent.com/1745504/125444673-4064f239-ef6c-475e-899b-2d56202390cf.png)

`TimelineStyle` now has an additional property `public var eventLayout: TimelineEventLayout = DefaultTimelineEventLayout()`
`TimelineView` now has an additional property `private(set) var eventLayout: TimelineEventLayout`, which will be set to `style.eventLayout` on init.

As you might have noticed, the original behaviour is now encapsulated within `DefaultTimelineEventLayout`.

Let me know what you think of this.
