### PR TITLE
allow custom shortInDayMonthFormatter

### DIFF
--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -322,11 +322,11 @@ public struct MonthStyle {
         format.dateFormat = "EE"
         return format
     }()
-    public var shortInDayMonthFormatter: DateFormatter {
+    public var shortInDayMonthFormatter: DateFormatter = {
         let format = DateFormatter()
         format.dateFormat = "MMM"
         return format
-    }
+    }()
     public var heightHeaderWeek: CGFloat = 25
     
     @available(swift, deprecated: 0.5.5, obsoleted: 0.5.6, renamed: "heightTitleHeader")


### PR DESCRIPTION
allows for custom DateFormatter for shortInDayMonthFormatter

Came across a simple customization approach but got stock with `shortInDayMonthFormatter` was a computed value instead of a public property like weekdayFormatter, etc.

It simply allowed me to do this when setting up a `Style`
```
let formatter = DateFormatter()
formatter.dateFormat = "MMM yyyy"
style.month. shortInDayMonthFormatter = formatter
```

Please consider this as an enhancement and available in SPM, I currently have this fix as a local SPM just to get this simple feature.