### PR TITLE
Fixed ScrollableWeekView not aligning with week day sections when style.timeline.useDefaultCorderHeader is false and type is week

### DIFF
--- a/Sources/KVKCalendar/ScrollableWeekView.swift
+++ b/Sources/KVKCalendar/ScrollableWeekView.swift
@@ -292,6 +292,17 @@ extension ScrollableWeekView: CalendarSettingProtocol {
                 
                 mainFrame.origin.x = cornerBtn.frame.width
                 mainFrame.size.width -= cornerBtn.frame.width
+            } else {
+                if type == .week {
+                    let spacerView = UIView()
+                    spacerView.frame = CGRect(x: 0, y: 0,
+                                              width: leftOffsetWithAdditionalTime,
+                                              height: bounds.height)
+                    spacerView.backgroundColor = .clear
+                    addSubview(spacerView)
+                    mainFrame.origin.x = spacerView.frame.width
+                    mainFrame.size.width -= spacerView.frame.width
+                }
             }
             
             if Platform.currentInterface != .phone {


### PR DESCRIPTION
When style.timeline.useDefaultCorderHeader is not set by the user, it is by default false. This leads to the ScrollableWeekView not being placed properly following the week day sections. 

**Expected Behaviour:**
The week day dates should align with corresponding week day sections when the view type is week.

**Picture:**
Before
<img src="https://user-images.githubusercontent.com/50199254/224737957-1be2fda9-d82b-4e35-ad39-309b0f1a6e22.png" width="300" height="650">

After
<img src="https://user-images.githubusercontent.com/50199254/224738128-e18dfa5f-b23d-4e95-8643-cfb8715ce8b5.png" width="300" height="650">