### PR TITLE
fix(#340): use the size of timeline slot as event preview size if it is set to nil

### DIFF
--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -189,6 +189,7 @@ public struct TimelineStyle {
     public var timeDividerFont: UIFont = .systemFont(ofSize: 10)
     public var scale: Scale? = Scale(min: 1, max: 6)
     public var useDefaultCorderHeader = false
+    public var eventPreviewSize: CGSize? = CGSize(width: 150, height: 150)
     
     public var allLeftOffset: CGFloat {
         widthTime + offsetTimeX + offsetLineLeft

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -610,7 +610,7 @@ extension TimelineView: EventDelegate {
         eventPreview = nil
         
         if view is EventView {
-            eventPreviewSize = CGSize(width: 150, height: 150)
+            eventPreviewSize = getEventPreviewSize()
             eventPreview = EventView(event: event,
                                      style: style,
                                      frame: CGRect(origin: CGPoint(x: location.x - eventPreviewXOffset,
@@ -797,6 +797,16 @@ extension TimelineView: CalendarSettingProtocol {
         let right = scrollView.rightAnchor.constraint(equalTo: rightAnchor)
         let bottom = scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
         NSLayoutConstraint.activate([top, left, right, bottom])
+    }
+
+    func getEventPreviewSize() -> CGSize {
+        if let styleSize = paramaters.style.timeline.eventPreviewSize {
+            return styleSize
+        }
+        
+        let width = (frame.width - leftOffsetWithAdditionalTime) / CGFloat(dates.count)
+        let height = calculatedTimeY + style.timeline.heightTime
+        return CGSize(width: width, height: height)
     }
 }
 

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -36,7 +36,10 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
     }
     var eventPreview: UIView?
     var eventResizePreview: ResizeEventView?
-    var eventPreviewSize = CGSize(width: 150, height: 150)
+    lazy var eventPreviewSize: CGSize = {
+        getEventPreviewSize()
+    }()
+
     var isResizableEventEnable = false
     var forceDisableScrollToCurrentTime = false
     var potentiallyCenteredLabel: TimelineLabel?


### PR DESCRIPTION
Hi Sergei, I found a bug that the event preview size will become the size of the last tapped event in Day View.
I reported it in [#340](https://github.com/kvyatkovskys/KVKCalendar/issues/340), and this is a fix for it.
Could you update the pod version after approving this, please?
Thanks!