### PR TITLE
fix(#340): use the size of timeline slot as event preview size

### DIFF
--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -410,7 +410,9 @@ extension TimelineView {
     
     @objc func addNewEvent(gesture: UILongPressGestureRecognizer) {
         guard !isResizableEventEnable else { return }
-        eventPreviewSize = getEventPreviewSize()
+        if gesture.state == .began {
+            eventPreviewSize = getEventPreviewSize()
+        }
         var point = gesture.location(in: scrollView)
         point.y = (point.y - eventPreviewYOffset) - style.timeline.offsetEvent - 6
         let time = movingMinuteLabel.time

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -410,7 +410,7 @@ extension TimelineView {
     
     @objc func addNewEvent(gesture: UILongPressGestureRecognizer) {
         guard !isResizableEventEnable else { return }
-        
+        eventPreviewSize = getEventPreviewSize()
         var point = gesture.location(in: scrollView)
         point.y = (point.y - eventPreviewYOffset) - style.timeline.offsetEvent - 6
         let time = movingMinuteLabel.time


### PR DESCRIPTION
The previous fix does not fix the issue on the custom event view. When an event of custom event type is moved, `eventPreviewSize` is set to the size of this event. So when a new event is added, the event preview shown on the screen is the size of the last moved event.
This fix reset `eventPreviewSize` in `func addNewEvent()`