### PR TITLE
【Important】Fix DateFormatter locale

### DIFF
--- a/Example/KVKCalendar/KVKCalendarSettings.swift
+++ b/Example/KVKCalendar/KVKCalendarSettings.swift
@@ -25,8 +25,8 @@ extension KVKCalendarSettings where Self: KVKCalendarDataModel {
         var eventTemp = event
         guard let startTemp = start, let endTemp = end else { return nil }
         
-        let startTime = timeFormatter(date: startTemp, format: style.timeSystem.format)
-        let endTime = timeFormatter(date: endTemp, format: style.timeSystem.format)
+        let startTime = timeFormatter(date: startTemp, format: style.timeSystem.format, local: style.locale)
+        let endTime = timeFormatter(date: endTemp, format: style.timeSystem.format, local: style.locale)
         eventTemp.start = startTemp
         eventTemp.end = endTemp
         eventTemp.title = TextEvent(timeline: "\(startTime) - \(endTime)\n new time",
@@ -59,8 +59,8 @@ extension KVKCalendarSettings where Self: KVKCalendarDataModel {
         guard let start = date,
               let end = Calendar.current.date(byAdding: .minute, value: 30, to: start) else { return nil }
         
-        let startTime = timeFormatter(date: start, format: style.timeSystem.format)
-        let endTime = timeFormatter(date: end, format: style.timeSystem.format)
+        let startTime = timeFormatter(date: start, format: style.timeSystem.format, local: style.locale)
+        let endTime = timeFormatter(date: end, format: style.timeSystem.format, local: style.locale)
         newEvent.start = start
         newEvent.end = end
         newEvent.ID = "\(events.count + 1)"
@@ -73,8 +73,8 @@ extension KVKCalendarSettings where Self: KVKCalendarDataModel {
     func handleEvents(systemEvents: [EKEvent]) -> [Event] {
         // if you want to get a system events, you need to set style.systemCalendars = ["test"]
         let mappedEvents = systemEvents.compactMap { (event) -> Event in
-            let startTime = timeFormatter(date: event.startDate, format: style.timeSystem.format)
-            let endTime = timeFormatter(date: event.endDate, format: style.timeSystem.format)
+            let startTime = timeFormatter(date: event.startDate, format: style.timeSystem.format, local: style.locale)
+            let endTime = timeFormatter(date: event.endDate, format: style.timeSystem.format, local: style.locale)
             event.title = "\(startTime) - \(endTime)\n\(event.title ?? "")"
             
             return Event(event: event)
@@ -91,11 +91,11 @@ extension KVKCalendarSettings where Self: KVKCalendarDataModel {
               let result = try? decoder.decode(ItemData.self, from: data) else { return }
         
         let events = result.data.compactMap({ (item) -> Event in
-            let startDate = formatter(date: item.start)
-            let endDate = formatter(date: item.end)
-            let startTime = timeFormatter(date: startDate, format: dateFormat)
-            let endTime = timeFormatter(date: endDate, format: dateFormat)
-            
+            let startDate = formatter(date: item.start, local: style.locale)
+            let endDate = formatter(date: item.end, local: style.locale)
+            let startTime = timeFormatter(date: startDate, format: dateFormat, local: style.locale)
+            let endTime = timeFormatter(date: endDate, format: dateFormat, local: style.locale)
+
             var event = Event(ID: item.id)
             event.start = startDate
             event.end = endDate
@@ -203,16 +203,18 @@ extension KVKCalendarSettings {
         style.timeline.useDefaultCorderHeader = true
         return style
     }
-    
-    func timeFormatter(date: Date, format: String) -> String {
+
+    func timeFormatter(date: Date, format: String, local: Locale) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
+        formatter.locale = local
         return formatter.string(from: date)
     }
     
-    func formatter(date: String) -> Date {
+    func formatter(date: String, local: Locale) -> Date {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        formatter.locale = local
         return formatter.date(from: date) ?? Date()
     }
     

--- a/Sources/KVKCalendar/CalendarData.swift
+++ b/Sources/KVKCalendar/CalendarData.swift
@@ -90,7 +90,7 @@ struct CalendarData {
 
         let formatterDay = DateFormatter()
         formatterDay.dateFormat = "EE"
-        formatterDay.locale = Locale(identifier: "en_US")
+        formatterDay.locale = style.locale
         let days = arrDates.map({ Day(type: DayType(rawValue: formatterDay.string(from: $0).uppercased()) ?? .empty, date: $0, data: []) })
         return days
     }

--- a/Sources/KVKCalendar/CalendarModel.swift
+++ b/Sources/KVKCalendar/CalendarModel.swift
@@ -399,6 +399,7 @@ extension CalendarSettingProtocol {
     func timeFormatter(date: Date, format: String) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
+        formatter.locale = style.locale
         return formatter.string(from: date)
     }
 }

--- a/Sources/KVKCalendar/CurrentLineView.swift
+++ b/Sources/KVKCalendar/CurrentLineView.swift
@@ -52,6 +52,7 @@ final class CurrentLineView: UIView {
         self.parameters = parameters
         super.init(frame: frame)
         isUserInteractionEnabled = false
+        formatter.locale = style.locale
         setUI()
     }
     

--- a/Sources/KVKCalendar/MonthCell.swift
+++ b/Sources/KVKCalendar/MonthCell.swift
@@ -31,6 +31,7 @@ final class MonthCell: KVKCollectionViewCell {
     private func timeFormatter(date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = style.timeSystem.format
+        formatter.locale = style.locale
         return formatter.string(from: date)
     }
     

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -108,6 +108,8 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         self.selectedDate = Date()
         super.init(frame: frame)
         
+        timeLabelFormatter.locale = style.locale
+
         addSubview(scrollView)
         setupConstraints()
         

--- a/Sources/KVKCalendar/YearView.swift
+++ b/Sources/KVKCalendar/YearView.swift
@@ -209,6 +209,7 @@ extension YearView: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout
         let index = getIndexForDirection(data.style.year.scrollDirection, indexPath: indexPath)
         let date = data.sections[index.section].months[index.row].date
         let formatter = DateFormatter()
+        formatter.locale = style.locale
         formatter.dateFormat = "dd.MM.yyyy"
         let newDate = formatter.date(from: "\(data.date.kvkDay).\(date.kvkMonth).\(date.kvkYear)")
         data.date = newDate ?? Date()


### PR DESCRIPTION
In non-US regions, `DateFormatter` needs to manually set the `locale` to correspond to the user's device time zone, otherwise the `date(from:)` method may return `nil`.

Related question: https://stackoverflow.com/questions/41206810/dateformatter-date-from-string-returns-nil