### PR TITLE
Add `isEndOfDayZero` to `Style`

### DIFF
--- a/Sources/KVKCalendar/CalendarModel.swift
+++ b/Sources/KVKCalendar/CalendarModel.swift
@@ -31,7 +31,7 @@ public enum TimeHourSystem: Int {
     case twelve = 12
     case twentyFour = 24
     
-    var hours: [String] {
+    func getHours(isEndOfDayZero: Bool = true) -> [String] {
         switch self {
         case .twelveHour, .twelve:
             let array = ["12"] + Array(1...11).map { String($0) }
@@ -45,7 +45,7 @@ public enum TimeHourSystem: Int {
             return am + pm
         case .twentyFourHour, .twentyFour:
             let array = ["00:00"] + Array(1...24).map { (i) -> String in
-                let i = i % 24
+                let i = isEndOfDayZero ? i % 24 : i 
                 var string = i < 10 ? "0" + "\(i)" : "\(i)"
                 string.append(":00")
                 return string

--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -608,6 +608,7 @@ extension Style: Equatable {
         && compare(\.timezone)
         && compare(\.defaultType)
         && compare(\.timeSystem)
+        && compare(\.isEndOfDayZero)
         && compare(\.startWeekDay)
         && compare(\.followInSystemTheme)
         && compare(\.systemCalendars)

--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -25,6 +25,8 @@ public struct Style {
     public var timezone = TimeZone.current
     public var defaultType: CalendarType?
     public var timeSystem: TimeHourSystem = .twentyFour
+    /// Only valid in 24-hour format
+    public var isEndOfDayZero: Bool = true
     public var startWeekDay: StartDayType = .monday
     public var followInSystemTheme: Bool = true
     public var systemCalendars: Set<String> = []

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -323,7 +323,7 @@ extension TimelineView {
     func createTimesLabel(start: Int) -> (times: [TimelineLabel], items: [UILabel]) {
         var times = [TimelineLabel]()
         var otherTimes = [UILabel]()
-        for (idx, txtHour) in timeSystem.hours.enumerated() where idx >= start {
+        for (idx, txtHour) in timeSystem.getHours(isEndOfDayZero: style.isEndOfDayZero).enumerated() where idx >= start {
             let yTime = (calculatedTimeY + style.timeline.heightTime) * CGFloat(idx - start)
             let time = TimelineLabel(frame: CGRect(x: leftOffsetWithAdditionalTime,
                                                    y: yTime,
@@ -333,7 +333,7 @@ extension TimelineView {
             time.textAlignment = style.timeline.timeAlignment
             time.textColor = style.timeline.timeColor
             time.text = txtHour
-            let hourTmp = TimeHourSystem.twentyFour.hours[idx]
+            let hourTmp = TimeHourSystem.twentyFour.getHours(isEndOfDayZero: style.isEndOfDayZero)[idx]
             let hour = timeLabelFormatter.date(from: hourTmp)?.kvkHour ?? 0
             time.hashTime = hour
             time.tag = idx - start


### PR DESCRIPTION
Allows display of "24:00" as the end of the day

Another way to do this is to set it to the associated value of `TimeHourSystem.twentyFour`. However, since `TimeHourSystem` itself carries the `rawValue`, I did not use this approach.