### PR TITLE
Add event without `.move`

### DIFF
--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -194,7 +194,9 @@ public struct TimelineStyle {
     public var scale: Scale? = Scale(min: 1, max: 6)
     public var useDefaultCorderHeader = false
     public var eventPreviewSize: CGSize? = CGSize(width: 150, height: 150)
-    
+    /// Takes effect when `style.event.states` does not contain `.move`. `true`: create a new event at the long press; `false`: create at the start time.
+    public var createEventAtTouch = false
+
     public var allLeftOffset: CGFloat {
         widthTime + offsetTimeX + offsetLineLeft
     }
@@ -889,6 +891,7 @@ extension TimelineStyle: Equatable {
         && compare(\.timeDividerColor)
         && compare(\.timeDividerFont)
         && compare(\.scale)
+        && compare(\.createEventAtTouch)
     }
     
 }

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -414,7 +414,7 @@ extension TimelineView {
             eventPreviewSize = getEventPreviewSize()
         }
         var point = gesture.location(in: scrollView)
-        if !style.event.states.contains(.move) {
+        if style.timeline.createEventAtTouch && !style.event.states.contains(.move) {
             let offset = eventPreviewYOffset - style.timeline.offsetEvent - 6
             showChangingMinute(pointY: point.y, offset: offset)
         }

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -415,6 +415,12 @@ extension TimelineView {
         }
         var point = gesture.location(in: scrollView)
         point.y = (point.y - eventPreviewYOffset) - style.timeline.offsetEvent - 6
+        
+        if !style.event.states.contains(.move) {
+            let location = gesture.location(in: scrollView)
+            let offset = eventPreviewYOffset - style.timeline.offsetEvent - 6
+            showChangingMinute(pointY: location.y, offset: offset)
+        }
         let time = movingMinuteLabel.time
         var newEvent = Event(ID: Event.idForNewEvent)
         newEvent.title = TextEvent(timeline: style.event.textForNewEvent)

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -414,13 +414,12 @@ extension TimelineView {
             eventPreviewSize = getEventPreviewSize()
         }
         var point = gesture.location(in: scrollView)
-        point.y = (point.y - eventPreviewYOffset) - style.timeline.offsetEvent - 6
-        
         if !style.event.states.contains(.move) {
-            let location = gesture.location(in: scrollView)
             let offset = eventPreviewYOffset - style.timeline.offsetEvent - 6
-            showChangingMinute(pointY: location.y, offset: offset)
+            showChangingMinute(pointY: point.y, offset: offset)
         }
+        point.y = (point.y - eventPreviewYOffset) - style.timeline.offsetEvent - 6
+
         let time = movingMinuteLabel.time
         var newEvent = Event(ID: Event.idForNewEvent)
         newEvent.title = TextEvent(timeline: style.event.textForNewEvent)


### PR DESCRIPTION
When `style.event.states` does not contain `.move`, this pr allows adding events where the user long presses, instead of adding the event to the front.

I didn't add a property in `Style` to control this behavior, because I think adding an event at the finger long press is in line with common sense of interaction.

If there is a need to add a control property, I can add it.