### PR TITLE
Add new delegate to additionally control whether events can be added currently

### DIFF
--- a/Sources/KVKCalendar/CalendarModel.swift
+++ b/Sources/KVKCalendar/CalendarModel.swift
@@ -541,6 +541,9 @@ public protocol CalendarDelegate: AnyObject {
     /// drag & drop events and resize
     func didChangeEvent(_ event: Event, start: Date?, end: Date?)
     
+    /// Controls whether event can be added
+    func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool
+
     /// add new event
     func didAddNewEvent(_ event: Event, _ date: Date?)
     
@@ -581,7 +584,9 @@ public extension CalendarDelegate {
     func eventViewerFrame(_ frame: CGRect) {}
     
     func didChangeEvent(_ event: Event, start: Date?, end: Date?) {}
-        
+    
+    func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool { true }
+    
     func didAddNewEvent(_ event: Event, _ date: Date?) {}
     
     func didDisplayEvents(_ events: [Event], dates: [Date?]) {}

--- a/Sources/KVKCalendar/DayView.swift
+++ b/Sources/KVKCalendar/DayView.swift
@@ -129,6 +129,17 @@ extension DayView: TimelineDelegate {
         delegate?.didChangeEvent(event, start: startDate, end: endDate)
     }
     
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool {
+        var components = DateComponents()
+        components.year = parameters.data.date.kvkYear
+        components.month = parameters.data.date.kvkMonth
+        components.day = parameters.data.date.kvkDay
+        components.hour = hour
+        components.minute = minute
+        let date = style.calendar.date(from: components)
+        return delegate?.willAddNewEvent(event, date) ?? true
+    }
+    
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {
         var components = DateComponents()
         components.year = parameters.data.date.kvkYear

--- a/Sources/KVKCalendar/DayView.swift
+++ b/Sources/KVKCalendar/DayView.swift
@@ -9,7 +9,7 @@
 
 import UIKit
 
-final class DayView: UIView {
+public final class DayView: UIView {
     
     private var parameters: Parameters
     private let tagEventViewer = -10
@@ -29,7 +29,7 @@ final class DayView: UIView {
                                                                   type: .day,
                                                                   style: Style()))
     
-    var timelinePage = TimelinePageView(maxLimit: 0, pages: [], frame: .zero)
+    public var timelinePage = TimelinePageView(maxLimit: 0, pages: [], frame: .zero)
     
     private var topBackgroundView = UIView()
     private var isAvailableEventViewer: Bool {

--- a/Sources/KVKCalendar/KVKCalendarView+Extension.swift
+++ b/Sources/KVKCalendar/KVKCalendarView+Extension.swift
@@ -331,6 +331,10 @@ extension KVKCalendarView: DisplayDelegate {
         delegate?.didSelectMore(date, frame: frame)
     }
     
+    public func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool {
+        delegate?.willAddNewEvent(event, date) ?? true
+    }
+
     public func didAddNewEvent(_ event: Event, _ date: Date?) {
         delegate?.didAddNewEvent(event, date)
     }

--- a/Sources/KVKCalendar/KVKCalendarView.swift
+++ b/Sources/KVKCalendar/KVKCalendarView.swift
@@ -42,7 +42,7 @@ public final class KVKCalendarView: UIView {
     private(set) var yearData: YearData
     private let listData: ListViewData
     
-    private(set) var dayView: DayView
+    public private(set) var dayView: DayView
     private(set) var weekView: WeekView
     private(set) var monthView: MonthView
     private(set) var yearView: YearView

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -44,7 +44,7 @@ extension TimelineView: UIScrollViewDelegate {
         }
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         addStubForInvisibleEvents()
     }
     
@@ -201,7 +201,7 @@ extension TimelineView {
         enableAllEvents(enable: true)
     }
     
-    private func enableAllEvents(enable: Bool) {
+    public func enableAllEvents(enable: Bool) {
         if style.allDay.isPinned {
             subviews.filter { $0.tag == tagAllDayEventView }.forEach { $0.isUserInteractionEnabled = enable }
         } else {
@@ -316,7 +316,7 @@ extension TimelineView {
         return allDayView
     }
     
-    func getTimelineLabel(hour: Int) -> TimelineLabel? {
+    public func getTimelineLabel(hour: Int) -> TimelineLabel? {
         timeLabels.first(where: { $0.hashTime == hour })
     }
     

--- a/Sources/KVKCalendar/TimelineModel.swift
+++ b/Sources/KVKCalendar/TimelineModel.swift
@@ -23,6 +23,7 @@ protocol TimelineDelegate: AnyObject {
     func previousDate()
     func swipeX(transform: CGAffineTransform, stop: Bool)
     func didChangeEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint, newDate: Date?)
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint)
     func didResizeEvent(_ event: Event, startTime: ResizeTime, endTime: ResizeTime)
     func dequeueTimeLabel(_ label: TimelineLabel) -> (current: TimelineLabel, others: [UILabel])?

--- a/Sources/KVKCalendar/TimelineModel.swift
+++ b/Sources/KVKCalendar/TimelineModel.swift
@@ -9,9 +9,14 @@
 
 import UIKit
 
-struct TimeContainer {
-    var minute: Int
-    var hour: Int
+public struct TimeContainer {
+    public var minute: Int
+    public var hour: Int
+
+    public init(minute: Int, hour: Int) {
+        self.minute = minute
+        self.hour = hour
+    }
 }
 
 typealias ResizeTime = (hour: Int, minute: Int)

--- a/Sources/KVKCalendar/TimelinePageView.swift
+++ b/Sources/KVKCalendar/TimelinePageView.swift
@@ -9,7 +9,7 @@
 
 import UIKit
 
-final class TimelinePageView: UIView {
+public final class TimelinePageView: UIView {
     
     enum SwitchPageType: Int {
         case next, previous
@@ -35,7 +35,7 @@ final class TimelinePageView: UIView {
     var didSwitchTimelineView: ((TimelineView?, SwitchPageType) -> Void)?
     var willDisplayTimelineView: ((TimelineView, SwitchPageType) -> Void)?
     
-    var timelineView: TimelineView? {
+    public var timelineView: TimelineView? {
         pages[currentIndex]
     }
     
@@ -156,14 +156,14 @@ final class TimelinePageView: UIView {
 
 extension TimelinePageView: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
-    func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
+    public func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
         guard let vc = pendingViewControllers.first as? TimelineContainerVC, let contentOffset = timelineView?.contentOffset else { return }
         
         let pendingTimelineView = pages[vc.index]
         pendingTimelineView?.contentOffset = contentOffset
     }
     
-    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+    public func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard var newIndex = (viewController as? TimelineContainerVC)?.index, isPagingEnabled else { return nil }
         
         newIndex -= 1
@@ -178,7 +178,7 @@ extension TimelinePageView: UIPageViewControllerDataSource, UIPageViewController
         return container
     }
     
-    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+    public func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard var newIndex = (viewController as? TimelineContainerVC)?.index, isPagingEnabled else { return nil }
         
         newIndex += 1
@@ -193,7 +193,7 @@ extension TimelinePageView: UIPageViewControllerDataSource, UIPageViewController
         return container
     }
     
-    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+    public func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         guard let index = (pageViewController.viewControllers?.first as? TimelineContainerVC)?.index, completed else { return }
                 
         let type: SwitchPageType

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -9,7 +9,7 @@
 
 import UIKit
 
-final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
+public final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
     
     struct Parameters {
         var style: Style
@@ -61,7 +61,7 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
     private let tagBackgroundView = -50
     private(set) var tagAllDayEventView = -70
     private(set) var tagStubEvent = -80
-    private(set) var timeLabels = [TimelineLabel]()
+    public private(set) var timeLabels = [TimelineLabel]()
     private(set) var timeSystem: TimeHourSystem
     private let timerKey = "CurrentHourTimerKey"
     private(set) var events = [Event]()
@@ -78,7 +78,7 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         return view
     }()
     
-    private(set) lazy var movingMinuteLabel: TimelineLabel = {
+    public private(set) lazy var movingMinuteLabel: TimelineLabel = {
         let label = TimelineLabel()
         label.adjustsFontSizeToFitWidth = true
         label.textColor = style.timeline.movingMinutesColor
@@ -95,7 +95,7 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         return view
     }()
     
-    private(set) lazy var scrollView: UIScrollView = {
+    public private(set) lazy var scrollView: UIScrollView = {
         let scroll = UIScrollView()
         scroll.delegate = self
         return scroll

--- a/Sources/KVKCalendar/WeekView.swift
+++ b/Sources/KVKCalendar/WeekView.swift
@@ -365,6 +365,17 @@ extension WeekView: TimelineDelegate {
         delegate?.didChangeEvent(event, start: startDate, end: endDate)
     }
     
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool {
+        var components = DateComponents()
+        components.year = event.start.kvkYear
+        components.month = event.start.kvkMonth
+        components.day = event.start.kvkDay
+        components.hour = hour
+        components.minute = minute
+        let newDate = style.calendar.date(from: components)
+        return delegate?.willAddNewEvent(event, newDate) ?? true
+    }
+
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {
         var components = DateComponents()
         components.year = event.start.kvkYear


### PR DESCRIPTION
Users may need more fine-grained control over when events can be added.

For example, I now use a custom view (`CreateEventView`) similar to `ResizeEventView` as the initial view for creating events. Users can select the time when creating an event instead of adjusting the time in the form of editing.

At this time, `CreateEventView` is a special `EventViewGeneral`, which should prohibit the addition of new events when it appears. This can be easily achieved through the newly added proxy in this pr.