### PR TITLE
Support change enable of some gestures by style

### DIFF
--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -181,6 +181,7 @@ public struct TimelineStyle {
     public var minimumPressDuration: TimeInterval = 0.5
     public var isHiddenStubEvent: Bool = true
     public var isEnabledCreateNewEvent: Bool = true
+    public var isEnabledDefaultTapGestureRecognizer: Bool = true
     public var maxLimitCachedPages: UInt = 10
     public var scrollDirections: Set<ScrollDirectionType> = Set(ScrollDirectionType.allCases)
     public var dividerType: DividerType? = nil
@@ -870,6 +871,7 @@ extension TimelineStyle: Equatable {
         && compare(\.minimumPressDuration)
         && compare(\.isHiddenStubEvent)
         && compare(\.isEnabledCreateNewEvent)
+        && compare(\.isEnabledDefaultTapGestureRecognizer)
         && compare(\.maxLimitCachedPages)
         && compare(\.scrollDirections)
         && compare(\.dividerType)

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -764,14 +764,10 @@ extension TimelineView: CalendarSettingProtocol {
         
         scrollView.backgroundColor = style.timeline.backgroundColor
         scrollView.isScrollEnabled = style.timeline.scrollDirections.contains(.vertical)
-        gestureRecognizers?.forEach { $0.removeTarget(self, action: #selector(addNewEvent)) }
         
-        if style.timeline.isEnabledCreateNewEvent {
-            // long tap to create a new event preview
-            let longTap = UILongPressGestureRecognizer(target: self, action: #selector(addNewEvent))
-            longTap.minimumPressDuration = style.timeline.minimumPressDuration
-            addGestureRecognizer(longTap)
-        }
+        tapGestureRecognizer.isEnabled = style.timeline.isEnabledDefaultTapGestureRecognizer
+        longTapGestureRecognizer.isEnabled = style.timeline.isEnabledCreateNewEvent
+        longTapGestureRecognizer.minimumPressDuration = style.timeline.minimumPressDuration
     }
     
     func reloadFrame(_ frame: CGRect) {

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -101,6 +101,10 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         return scroll
     }()
     
+    private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(forceDeselectEvent))
+    
+    private(set) lazy var longTapGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(addNewEvent))
+    
     init(parameters: Parameters, frame: CGRect) {
         self.paramaters = parameters
         self.timeSystem = parameters.style.timeSystem
@@ -111,8 +115,10 @@ final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         addSubview(scrollView)
         setupConstraints()
         
-        let tap = UITapGestureRecognizer(target: self, action: #selector(forceDeselectEvent))
-        addGestureRecognizer(tap)
+        addGestureRecognizer(tapGestureRecognizer)
+        
+        // long tap to create a new event preview
+        addGestureRecognizer(longTapGestureRecognizer)
         
         if style.timeline.scale != nil {
             let pinch = UIPinchGestureRecognizer(target: self, action: #selector(pinchZooming))


### PR DESCRIPTION
This modification gives users more precise control over the `Timeline` view by using the `isEnabled` property.

If the user does not need to resize(`style.event.states = []`) 
and does not support selection(`style.event.isEnableVisualSelect = false`), 
and wants to add additional tap gestures, 
the control property (`style.timeline.isEnabledDefaultTapGestureRecognizer`) added in this pr will come in handy.

At the same time, I also modified the gesture of long pressing to create events according to the above method, reducing the consumption caused by each additional creation.