### PR TITLE
Use the `willAddNewEvent(_: _:)` method that return `Event?` instead of the old method that return `Bool`.

### DIFF
--- a/Sources/KVKCalendar/CalendarModel.swift
+++ b/Sources/KVKCalendar/CalendarModel.swift
@@ -596,8 +596,10 @@ public extension CalendarDelegate {
     
     func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool { true }
     
-    func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? { event }
-    
+    func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? {
+        return willAddNewEvent(event, date) ? event : nil
+    }
+
     func didAddNewEvent(_ event: Event, _ date: Date?) {}
     
     func didDisplayEvents(_ events: [Event], dates: [Date?]) {}

--- a/Sources/KVKCalendar/CalendarModel.swift
+++ b/Sources/KVKCalendar/CalendarModel.swift
@@ -542,8 +542,16 @@ public protocol CalendarDelegate: AnyObject {
     /// drag & drop events and resize
     func didChangeEvent(_ event: Event, start: Date?, end: Date?)
     
-    /// Controls whether event can be added
+    /** The method is **DEPRECATED**
+        Use a new **willAddNewEvent(_: _:)** that returns `Event?`
+     */
+    @available(*, deprecated, message: "Use the `willAddNewEvent(_: _:)` method that returns `Event?` instead.")
     func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool
+
+    /// Controls whether event can be added
+    ///
+    /// Returns the modified Event object. `nil` means the event will not be added.
+    func willAddNewEvent(_ event: Event, _ date: Date?) -> Event?
 
     /// add new event
     func didAddNewEvent(_ event: Event, _ date: Date?)
@@ -587,6 +595,8 @@ public extension CalendarDelegate {
     func didChangeEvent(_ event: Event, start: Date?, end: Date?) {}
     
     func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool { true }
+    
+    func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? { event }
     
     func didAddNewEvent(_ event: Event, _ date: Date?) {}
     

--- a/Sources/KVKCalendar/DayView.swift
+++ b/Sources/KVKCalendar/DayView.swift
@@ -130,7 +130,7 @@ extension DayView: TimelineDelegate {
         delegate?.didChangeEvent(event, start: startDate, end: endDate)
     }
     
-    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool {
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Event? {
         var components = DateComponents()
         components.year = parameters.data.date.kvkYear
         components.month = parameters.data.date.kvkMonth
@@ -138,7 +138,7 @@ extension DayView: TimelineDelegate {
         components.hour = hour
         components.minute = minute
         let date = style.calendar.date(from: components)
-        return delegate?.willAddNewEvent(event, date) ?? true
+        return delegate?.willAddNewEvent(event, date) ?? event
     }
     
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {

--- a/Sources/KVKCalendar/KVKCalendarView+Extension.swift
+++ b/Sources/KVKCalendar/KVKCalendarView+Extension.swift
@@ -330,8 +330,8 @@ extension KVKCalendarView: DisplayDelegate {
         delegate?.didSelectMore(date, frame: frame)
     }
     
-    public func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool {
-        delegate?.willAddNewEvent(event, date) ?? true
+    public func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? {
+        delegate?.willAddNewEvent(event, date) ?? event
     }
 
     public func didAddNewEvent(_ event: Event, _ date: Date?) {

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -431,7 +431,15 @@ extension TimelineView {
         
         newEvent.end = style.calendar.date(byAdding: .minute, value: style.event.newEventStep, to: newEvent.start) ?? Date()
 
-        guard !isResizableEventEnable && (delegate?.willAddNewEvent(newEvent, minute: time.minute, hour: time.hour, point: point) ?? true) else { return }
+        guard  !isResizableEventEnable else { return }
+
+        if let delegate {
+            if let tmpNewEvent = delegate.willAddNewEvent(newEvent, minute: time.minute, hour: time.hour, point: point) {
+                newEvent = tmpNewEvent
+            } else {
+                return
+            }
+        }
         
         if gesture.state == .began {
             eventPreviewSize = getEventPreviewSize()

--- a/Sources/KVKCalendar/TimelineModel.swift
+++ b/Sources/KVKCalendar/TimelineModel.swift
@@ -28,7 +28,7 @@ protocol TimelineDelegate: AnyObject {
     func previousDate()
     func swipeX(transform: CGAffineTransform, stop: Bool)
     func didChangeEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint, newDate: Date?)
-    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Event?
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint)
     func didResizeEvent(_ event: Event, startTime: ResizeTime, endTime: ResizeTime)
     func dequeueTimeLabel(_ label: TimelineLabel) -> (current: TimelineLabel, others: [UILabel])?

--- a/Sources/KVKCalendar/WeekView.swift
+++ b/Sources/KVKCalendar/WeekView.swift
@@ -366,7 +366,7 @@ extension WeekView: TimelineDelegate {
         delegate?.didChangeEvent(event, start: startDate, end: endDate)
     }
     
-    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Bool {
+    func willAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) -> Event? {
         var components = DateComponents()
         components.year = event.start.kvkYear
         components.month = event.start.kvkMonth
@@ -374,7 +374,7 @@ extension WeekView: TimelineDelegate {
         components.hour = hour
         components.minute = minute
         let newDate = style.calendar.date(from: components)
-        return delegate?.willAddNewEvent(event, newDate) ?? true
+        return delegate?.willAddNewEvent(event, newDate) ?? event
     }
 
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {


### PR DESCRIPTION
Create conditions for modifying event.

For the current architecture, we have the following code:
```swift
func willAddNewEvent(_ event: Event, _ date: Date?) -> Bool {
    guard
        let date = date,
        // Add 1 second to avoid overlapping with the start time of subsequent events
        let start = style.calendar.date(byAdding: .second, value: 1, to: date),
        let end = style.calendar.date(byAdding: .hour, value: 1, to: date),
        !events.contains(where: { event in
            // When currently in the adding state || Long press at the time point of an existing event
            event.isNew || (start.sak.hour >= event.start.sak.hour && end.sak.hour <= event.end.sak.hour)
        })
    else {
        return false
    }

    let currentDate = Date()
    switch style.calendar.compare(end, to: currentDate, toGranularity: .day) {
    case .orderedSame:
        return end.sak.hour > currentDate.sak.hour

    case .orderedAscending:
        // Adding events with past dates is not allowed
        return false

    case .orderedDescending:
        return true
    }
}

func didAddNewEvent(_ event: Event, _ date: Date?) {
    guard
        let date = date,
        // Add 1 second to avoid overlapping with the start time of subsequent events
        let start = style.calendar.date(byAdding: .second, value: 1, to: date),
        let end = style.calendar.date(byAdding: .hour, value: 1, to: date)
    else {
        return
    }

    var newEvent = event
    newEvent.start = start
    newEvent.end = end

    events.append(newEvent)

    func _createTime(with keyPath: KeyPath<Event, Date>) -> TimeContainer {
        let tmpDate = newEvent[keyPath: keyPath].sak
        return .init(minute: tmpDate.minute, hour: tmpDate.hour)
    }

    startTime = _createTime(with: \.start)
    endTime = _createTime(with: \.end)
}
```

You can find two similar guard codes.

The new method in pr can simplify this process:
```swift
func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? {
    guard
        let date = date,
        // Add 1 second to avoid overlapping with the start time of subsequent events
        let start = style.calendar.date(byAdding: .second, value: 1, to: date),
        let end = style.calendar.date(byAdding: .hour, value: 1, to: date),
        !events.contains(where: { event in
            // When currently in the adding state || Long press at the time point of an existing event
            event.isNew || (start.sak.hour >= event.start.sak.hour && end.sak.hour <= event.end.sak.hour)
        })
    else {
        return nil
    }

    lazy var createNewEvent: () -> Event = {
        var newEvent = event
        newEvent.start = start
        newEvent.end = end
        return newEvent
    }

    let currentDate = Date()
    switch style.calendar.compare(end, to: currentDate, toGranularity: .day) {
    case .orderedSame:
        return (end.sak.hour > currentDate.sak.hour) ? createNewEvent() : nil

    case .orderedAscending:
        // Adding events with past dates is not allowed
        return nil

    case .orderedDescending:
        return createNewEvent()
    }
}

func didAddNewEvent(_ event: Event, _ date: Date?) {
    events.append(event)

    func _createTime(with keyPath: KeyPath<Event, Date>) -> TimeContainer {
        let tmpDate = event[keyPath: keyPath].sak
        return .init(minute: tmpDate.minute, hour: tmpDate.hour)
    }

    startTime = _createTime(with: \.start)
    endTime = _creat
}
```