### PR TITLE
Fix `delegate.willAddNewEvent` call issue

### DIFF
--- a/Sources/KVKCalendar/DayView.swift
+++ b/Sources/KVKCalendar/DayView.swift
@@ -138,7 +138,9 @@ extension DayView: TimelineDelegate {
         components.hour = hour
         components.minute = minute
         let date = style.calendar.date(from: components)
-        return delegate?.willAddNewEvent(event, date) ?? event
+
+        guard let delegate else { return event }
+        return delegate.willAddNewEvent(event, date)
     }
     
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {

--- a/Sources/KVKCalendar/KVKCalendarView+Extension.swift
+++ b/Sources/KVKCalendar/KVKCalendarView+Extension.swift
@@ -331,7 +331,8 @@ extension KVKCalendarView: DisplayDelegate {
     }
     
     public func willAddNewEvent(_ event: Event, _ date: Date?) -> Event? {
-        delegate?.willAddNewEvent(event, date) ?? event
+        guard let delegate else { return event }
+        return delegate.willAddNewEvent(event, date)
     }
 
     public func didAddNewEvent(_ event: Event, _ date: Date?) {

--- a/Sources/KVKCalendar/WeekView.swift
+++ b/Sources/KVKCalendar/WeekView.swift
@@ -376,7 +376,9 @@ extension WeekView: TimelineDelegate {
         components.hour = hour
         components.minute = minute
         let newDate = style.calendar.date(from: components)
-        return delegate?.willAddNewEvent(event, newDate) ?? event
+
+        guard let delegate else { return event }
+        return delegate.willAddNewEvent(event, newDate)
     }
 
     func didAddNewEvent(_ event: Event, minute: Int, hour: Int, point: CGPoint) {


### PR DESCRIPTION
When calling the `willAddNewEvent` method through `delegate`, you should not use `event` directly as the default value when the method returns `nil`, because `nil` is meaningful.

`event` should be used as the default value only when `delegate` is `nil`.

This change does not affect the compatibility of the `willAddNewEvent` method that returns the `Bool` type.