### PR TITLE
Allows creation of event to be triggered by tapping instead of long pressing

### DIFF
--- a/Sources/KVKCalendar/EventViewGeneral.swift
+++ b/Sources/KVKCalendar/EventViewGeneral.swift
@@ -96,7 +96,7 @@ open class EventViewGeneral: UIView, CalendarTimer {
         }
     }
     
-    @objc public func editEvent(gesture: UILongPressGestureRecognizer) {
+    @objc public func editEvent(gesture: UIGestureRecognizer) {
         let location = gesture.location(in: self)
         
         switch gesture.state {
@@ -197,11 +197,11 @@ extension EventViewGeneral {
 
 protocol EventDelegate: AnyObject {
     
-    func didStartResizeEvent(_ event: Event, gesture: UILongPressGestureRecognizer, view: UIView)
-    func didEndResizeEvent(_ event: Event, gesture: UILongPressGestureRecognizer)
-    func didStartMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer, view: UIView)
-    func didEndMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer)
-    func didChangeMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer)
+    func didStartResizeEvent(_ event: Event, gesture: UIGestureRecognizer, view: UIView)
+    func didEndResizeEvent(_ event: Event, gesture: UIGestureRecognizer)
+    func didStartMovingEvent(_ event: Event, gesture: UIGestureRecognizer, view: UIView)
+    func didEndMovingEvent(_ event: Event, gesture: UIGestureRecognizer)
+    func didChangeMovingEvent(_ event: Event, gesture: UIGestureRecognizer)
     func didSelectEvent(_ event: Event, gesture: UITapGestureRecognizer)
     func deselectEvent(_ event: Event)
     

--- a/Sources/KVKCalendar/Style.swift
+++ b/Sources/KVKCalendar/Style.swift
@@ -187,7 +187,9 @@ public struct TimelineStyle {
     public var minimumPressDuration: TimeInterval = 0.5
     public var isHiddenStubEvent: Bool = true
     public var isEnabledCreateNewEvent: Bool = true
+    public var isEnabledForceDeselectEvent: Bool = true
     public var isEnabledDefaultTapGestureRecognizer: Bool = true
+    public var createNewEventMethod: CreateNewEventMethod = .longTap
     public var maxLimitCachedPages: UInt = 10
     public var scrollDirections: Set<ScrollDirectionType> = Set(ScrollDirectionType.allCases)
     public var dividerType: DividerType? = nil
@@ -274,6 +276,10 @@ public struct TimelineStyle {
                 return false
             }
         }
+    }
+
+    public enum CreateNewEventMethod: Equatable {
+        case tap, longTap
     }
 }
 
@@ -897,6 +903,8 @@ extension TimelineStyle: Equatable {
         && compare(\.timeDividerFont)
         && compare(\.scale)
         && compare(\.createEventAtTouch)
+        && compare(\.createNewEventMethod)
+        && compare(\.isEnabledForceDeselectEvent)
     }
     
 }

--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -259,7 +259,20 @@ extension TimelineView {
         }
     }
     
-    @objc func forceDeselectEvent() {
+    @objc func handleDefaultTapGesture(gesture: UITapGestureRecognizer) {
+        // Record before unchecking
+        let hasCreateEvent = events.contains { $0.isNew }
+
+        if style.timeline.isEnabledForceDeselectEvent {
+            forceDeselectEvent()
+        }
+
+        if style.timeline.isEnabledCreateNewEvent && style.timeline.createNewEventMethod == .tap && !hasCreateEvent {
+            addNewEvent(gesture: gesture)
+        }
+    }
+
+    func forceDeselectEvent() {
         removeEventResizeView()
         
         guard let eventViewGeneral = scrollView.subviews.first(where: { ($0 as? EventViewGeneral)?.isSelected == true }) as? EventViewGeneral else { return }
@@ -408,7 +421,7 @@ extension TimelineView {
         }
     }
     
-    @objc func addNewEvent(gesture: UILongPressGestureRecognizer) {
+    @objc func addNewEvent(gesture: UIGestureRecognizer) {
         var point = gesture.location(in: scrollView)
         if style.timeline.createEventAtTouch && !style.event.states.contains(.move) {
             let offset = eventPreviewYOffset - style.timeline.offsetEvent - 6
@@ -576,7 +589,7 @@ extension TimelineView: EventDelegate {
         delegate?.didSelectEvent(event, frame: gesture.view?.frame)
     }
     
-    func didStartResizeEvent(_ event: Event, gesture: UILongPressGestureRecognizer, view: UIView) {
+    func didStartResizeEvent(_ event: Event, gesture: UIGestureRecognizer, view: UIView) {
         forceDeselectEvent()
         isResizableEventEnable = true
         
@@ -610,11 +623,11 @@ extension TimelineView: EventDelegate {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
     
-    func didEndResizeEvent(_ event: Event, gesture: UILongPressGestureRecognizer) {
+    func didEndResizeEvent(_ event: Event, gesture: UIGestureRecognizer) {
         removeEventResizeView()
     }
     
-    func didStartMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer, view: UIView) {
+    func didStartMovingEvent(_ event: Event, gesture: UIGestureRecognizer, view: UIView) {
         removeEventResizeView()
         let location = gesture.location(in: scrollView)
         
@@ -659,7 +672,7 @@ extension TimelineView: EventDelegate {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
     
-    func didEndMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer) {
+    func didEndMovingEvent(_ event: Event, gesture: UIGestureRecognizer) {
         eventPreview?.removeFromSuperview()
         eventPreview = nil
         movingMinuteLabel.removeFromSuperview()
@@ -692,7 +705,7 @@ extension TimelineView: EventDelegate {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
     
-    func didChangeMovingEvent(_ event: Event, gesture: UILongPressGestureRecognizer) {
+    func didChangeMovingEvent(_ event: Event, gesture: UIGestureRecognizer) {
         let location = gesture.location(in: scrollView)
         guard scrollView.frame.width >= (location.x + 20) &&
                 (location.x - 20) >= style.timeline.allLeftOffset else { return }
@@ -783,7 +796,7 @@ extension TimelineView: CalendarSettingProtocol {
         scrollView.isScrollEnabled = style.timeline.scrollDirections.contains(.vertical)
         
         tapGestureRecognizer.isEnabled = style.timeline.isEnabledDefaultTapGestureRecognizer
-        longTapGestureRecognizer.isEnabled = style.timeline.isEnabledCreateNewEvent
+        longTapGestureRecognizer.isEnabled = style.timeline.isEnabledCreateNewEvent && style.timeline.createNewEventMethod == .longTap
         longTapGestureRecognizer.minimumPressDuration = style.timeline.minimumPressDuration
     }
     

--- a/Sources/KVKCalendar/TimelineView.swift
+++ b/Sources/KVKCalendar/TimelineView.swift
@@ -101,8 +101,8 @@ public final class TimelineView: UIView, EventDateProtocol, CalendarTimer {
         return scroll
     }()
     
-    private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(forceDeselectEvent))
-    
+    private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleDefaultTapGesture(gesture:)))
+
     private(set) lazy var longTapGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(addNewEvent))
     
     init(parameters: Parameters, frame: CGRect) {


### PR DESCRIPTION
By setting `style.timeline.createNewEventMethod` to `.tap`, you can trigger the added action when clicking on the timeline.

**Note**: In the past, the call to the `forceDeselectEvent` method could be canceled by `isEnabledDefaultTapGestureRecognizer`, but now it is necessary to additionally set `isEnabledForceDeselectEvent = false`