### PR TITLE
Fixed the issue where `headerScroll.titleDays` was not called when `day.type` was `.empty`

### DIFF
--- a/Sources/KVKCalendar/DayCell.swift
+++ b/Sources/KVKCalendar/DayCell.swift
@@ -65,18 +65,19 @@ class DayCell: UICollectionViewCell {
             }
             
             dateLabel.text = "\(tempDay)"
-            guard day.type != .empty else {
-                titleLabel.text = day.date?.titleForLocale(style.locale, formatter: style.headerScroll.weekdayFormatter).capitalized
-                dateLabel.textColor = style.headerScroll.colorNameEmptyDay
-                titleLabel.textColor = style.headerScroll.colorNameEmptyDay
-                return
-            }
             
             if !style.headerScroll.titleDays.isEmpty, let title = style.headerScroll.titleDays[safe: day.date?.kvkWeekday ?? 0] {
                 titleLabel.text = title
             } else {
                 titleLabel.text = day.date?.titleForLocale(style.locale, formatter: style.headerScroll.weekdayFormatter).capitalized
             }
+            
+            guard day.type != .empty else {
+                dateLabel.textColor = style.headerScroll.colorNameEmptyDay
+                titleLabel.textColor = style.headerScroll.colorNameEmptyDay
+                return
+            }
+            
             populateCell(day)
         }
     }


### PR DESCRIPTION
Now in the code, when `day.type` is `.empty`, the following processing is performed:
```swift
guard day.type != .empty else {
    titleLabel.text = day.date?.titleForLocale(style.locale, formatter: style.headerScroll.weekdayFormatter).capitalized
    ...
    return
}
```

`titleLabel.text` is not set using the `style.headerScroll.titleDays` property, it is only applied when it is not `.empty`

I think this is an oversight, and this PR fixes it