### PR TITLE
Fix the DayCell style error caused by reuse

### DIFF
--- a/Sources/KVKCalendar/DayCell.swift
+++ b/Sources/KVKCalendar/DayCell.swift
@@ -84,7 +84,12 @@ class DayCell: UICollectionViewCell {
     
     var selectDate: Date = Date() {
         didSet {
-            guard day.type != .empty else { return }
+            guard day.type != .empty else {
+                titleLabel.textColor = style.headerScroll.colorNameEmptyDay
+                dotView.backgroundColor = .clear
+                isSelected = false
+                return
+            }
             
             let nowDate = Date()
             guard nowDate.kvkMonth != day.date?.kvkMonth else {


### PR DESCRIPTION
<img width="443" alt="image" src="https://github.com/user-attachments/assets/21206d24-8a38-48a4-a252-4e42e8b1040d">

As shown in the figure, under boundary conditions, due to cell reuse, the cell with the `empty` style may reuse the cell with the selected style, resulting in style errors.

This PR fixes this problem.