### PR TITLE
Bug fixes on tap gesture in WeekView mode.

### DIFF
--- a/Sources/KVKCalendar/Timeline+Extension.swift
+++ b/Sources/KVKCalendar/Timeline+Extension.swift
@@ -435,7 +435,8 @@ extension TimelineView {
         case .day:
             newEvent.start = selectedDate
         case .week:
-            newEvent.start = shadowView.date ?? Date()
+            let value = moveShadowView(pointX: point.x)
+            newEvent.start = shadowView.date ?? value?.date ?? Date()
         default:
             break
         }


### PR DESCRIPTION
This pull request addresses an issue in weekView where, upon selecting a time slot, the event was always created for the current day instead of the selected day. While the selected hour was accurately set for the event, the date consistently defaulted to today rather than reflecting the chosen date.

Before the changes:
https://github.com/user-attachments/assets/043c9f2b-9aad-40a9-9750-47bb180f4fad

After the changes:

https://github.com/user-attachments/assets/6373c7e3-118f-4749-ba3b-4a4dfa20b615

